### PR TITLE
Correctly match against Site & Community URLs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,8 +11,8 @@
   ],
   "content_scripts": [
     {
-      	"matches": ["https://*.salesforce.com/*", "https://*.visual.force.com/*"],
-		"js": ["contentscript.js"]
+      "matches": ["https://*.salesforce.com/*", "https://*.force.com/*"],
+      "js": ["contentscript.js"]
     }
   ]
 }


### PR DESCRIPTION
In sandbox, these URLs have format
https://sandboxname-domain.csXX.force.com/communityPrefix/
